### PR TITLE
Add support Bitcoin Cash currencies

### DIFF
--- a/src/utils/currencies.js
+++ b/src/utils/currencies.js
@@ -12,6 +12,11 @@ const CURRENCIES = [
     color: '#8C01FF',
   },
   {
+    name: 'Bitcoin Cash',
+    symbol: 'BCH',
+    color: '#FF7300',
+  },
+  {
     name: 'Litecoin',
     symbol: 'LTC',
     color: '#B4B4B4',


### PR DESCRIPTION
Bitcoin Cash was added to the list of currencies
supported by `lionshare` desktop.